### PR TITLE
Alterando tipo de instâncias EC2 para EKS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ module "eks" {
   # EKS Managed Node Group(s)
   eks_managed_node_group_defaults = {
     ami_type       = "AL2_x86_64"
-    instance_types = ["t3.micro"]
+    instance_types = ["t3.medium"]
 
     attach_cluster_primary_security_group = true
   }


### PR DESCRIPTION
t3.micro não é suficiente para EKS